### PR TITLE
feat(api): 월별 예산(Budget) API 구현 & Budget 모델/연관관계/제약 스키마

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   email     String    @unique
   phone     String?    
   expenses  Expense[]
+  budgets   Budget[] 
   createdAt DateTime  @default(now())
 
 }
@@ -35,4 +36,17 @@ model Expense {
   user      User     @relation(fields: [userId], references: [id])
   createdAt DateTime @default(now())
   expenseDate  DateTime // ✅ 지출한 실제 날짜
+}
+
+model Budget {
+  id        String   @id @default(cuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  year      Int
+  month     Int
+  amount    Int
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, year, month])
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,9 +5,16 @@ import { PrismaModule } from './prisma/prisma.module';
 import { ExpensesModule } from './expenses/expenses.module';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { BudgetsModule } from './budget/budget.module';
 
 @Module({
-  imports: [PrismaModule, ExpensesModule, UsersModule, AuthModule],
+  imports: [
+    PrismaModule,
+    ExpensesModule,
+    UsersModule,
+    AuthModule,
+    BudgetsModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/api/src/budget/budget.controller.ts
+++ b/apps/api/src/budget/budget.controller.ts
@@ -1,0 +1,83 @@
+import { Controller, Get, Body, Query, UseGuards, Post } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from 'src/auth/jwt/jwt.guard';
+
+import { BudgetsService } from './budget.service';
+
+import { getUser, AuthUser } from 'src/users/users.decorator';
+import { UpsertBudgetDto } from './dto/upsert-budget.dto';
+
+@ApiTags('Budget (예산 관련 API)')
+@Controller('budget')
+export class BudgetsController {
+  constructor(private readonly budgetsService: BudgetsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token') // 👈 위에서 설정한 name과 일치해야 함
+  @Get('status')
+  @ApiQuery({
+    name: 'year',
+    type: Number,
+    required: true,
+    description: '연도 (예: 2025)',
+  })
+  @ApiQuery({
+    name: 'month',
+    type: Number,
+    required: true,
+    description: '월 (1~12)',
+  })
+  @ApiOperation({
+    summary: '월별 예산 현황 조회',
+    description: '해당 연/월의 예산과 실제 지출을 확인합니다.',
+  })
+  async getStatus(
+    @getUser() user: AuthUser,
+    @Query('year') year: number,
+    @Query('month') month: number,
+  ) {
+    return this.budgetsService.getStatus(user.id, year, month);
+  }
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: '월별 예산 설정',
+    description: '특정 연/월의 예산을 생성 또는 수정합니다.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['year', 'month', 'amount'],
+      properties: {
+        year: {
+          type: 'integer',
+          example: 2025,
+          description: '년 (예: 2025)',
+        },
+        month: {
+          type: 'integer',
+          example: 6,
+          description: '월 (1~12)',
+        },
+
+        amount: {
+          type: 'integer',
+          example: 100000,
+          description: '예산 금액 (원 단위)',
+        },
+      },
+    },
+  })
+  upsertBudget(@getUser() user: AuthUser, @Body() dto: UpsertBudgetDto) {
+    return this.budgetsService.upsert(user.id, dto);
+  }
+}

--- a/apps/api/src/budget/budget.module.ts
+++ b/apps/api/src/budget/budget.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { BudgetsService } from './budget.service';
+import { BudgetsController } from './budget.controller';
+
+@Module({
+  providers: [BudgetsService],
+  controllers: [BudgetsController],
+  exports: [BudgetsService], // ✅ 꼭 export 해야 다른 모듈에서 사용 가능
+})
+export class BudgetsModule {}

--- a/apps/api/src/budget/budget.service.ts
+++ b/apps/api/src/budget/budget.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { endOfMonth } from 'date-fns';
+import { UpsertBudgetDto } from './dto/upsert-budget.dto';
+
+@Injectable()
+export class BudgetsService {
+  constructor(private prisma: PrismaService) {}
+
+  async upsert(userId: string, dto: UpsertBudgetDto) {
+    try {
+      await this.prisma.budget.upsert({
+        where: {
+          userId_year_month: {
+            userId,
+            year: dto.year,
+            month: dto.month,
+          },
+        },
+        update: { amount: dto.amount },
+        create: {
+          userId,
+          year: dto.year,
+          month: dto.month,
+          amount: dto.amount,
+        },
+      });
+    } catch (error) {
+      // 예외 발생 시 NestJS 예외로 변환
+      throw new InternalServerErrorException(
+        `예산 정보를 저장하는 데 실패했습니다. ${error}`,
+      );
+    }
+  }
+  async getStatus(userId: string, year: number, month: number) {
+    const start = new Date(`${year}-${String(month).padStart(2, '0')}-01`);
+    const end = endOfMonth(start);
+
+    const budget = await this.prisma.budget.findUnique({
+      where: {
+        userId_year_month: {
+          userId,
+          year: Number(year),
+          month: Number(month),
+        },
+      },
+    });
+
+    const expenses = await this.prisma.expense.aggregate({
+      _sum: { amount: true },
+      where: {
+        userId,
+        expenseDate: { gte: start, lte: end },
+      },
+    });
+
+    const budgetAmount = budget?.amount ?? 0;
+    const spent = expenses._sum.amount ?? 0;
+
+    return {
+      year,
+      month,
+      hasBudget: !!budget, // ✅ 예산 존재 여부
+      budget: budgetAmount,
+      spent,
+      remaining: budgetAmount - spent,
+    };
+  }
+}

--- a/apps/api/src/budget/dto/upsert-budget.dto.ts
+++ b/apps/api/src/budget/dto/upsert-budget.dto.ts
@@ -1,0 +1,14 @@
+import { IsInt, Min, Max } from 'class-validator';
+
+export class UpsertBudgetDto {
+  @IsInt()
+  year: number;
+
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  month: number;
+
+  @IsInt()
+  amount: number;
+}


### PR DESCRIPTION
* 예산 생성/수정(upsert) 및 월별 예산 현황 조회 엔드포인트 추가
* BudgetsService에 예산 upsert, getStatus 로직 구현
* Prisma 스키마에 Budget 모델 정의 및 User와 관계 설정
* Swagger 문서화 및 JWT 인증 적용
* AppModule에 BudgetsModule 등록