### PR TITLE
feat(types): add shared SbSignInRequest and SbSignUpRequest

### DIFF
--- a/apps/web/@utils/apis/auth.ts
+++ b/apps/web/@utils/apis/auth.ts
@@ -1,19 +1,10 @@
 import {
-  AuthUser,
+  SupabaseSignInRequest,
+  SupabaseSignUpRequest,
   SupabaseSignInResponse,
   SupabaseSignUpResponse,
 } from "@repo/types";
 import { ApiRoute, AuthRoute } from "../../@constant/api.route";
-
-interface SupabaseSignInRequest {
-  email: AuthUser["email"];
-  password: string;
-}
-
-interface SupabaseSignUpRequest {
-  email: AuthUser["email"];
-  password: string;
-}
 
 export const signIn = async (payload: { email: string; password: string }) => {
   const res = await fetch("/api/auth/signin", {

--- a/packages/types/src/SupabaseAuth.ts
+++ b/packages/types/src/SupabaseAuth.ts
@@ -30,7 +30,15 @@ export interface SupabaseSignInResponse {
   refresh_token: string;
   user: SupabaseUser;
 }
+export interface SupabaseSignInRequest {
+  email: SupabaseUser["email"];
+  password: string;
+}
 
+export interface SupabaseSignUpRequest {
+  email: SupabaseUser["email"];
+  password: string;
+}
 export interface AuthUser {
   id: SupabaseUser["id"];
   email: SupabaseUser["email"];


### PR DESCRIPTION
* Supabase 인증 관련 타입(SupabaseUser, SupabaseSignInRequest, SupabaseSignUpRequest 등) 정의
* API 응답 및 요청에 사용할 공통 타입을 패키지로 분리하여 재사용성 향상
* 기존 auth.types.ts의 타입을 패키지로 이동
* 타입 일관성 및 유지보수성 개선