### PR TITLE
feat(api-expenseStreak): 지출 연속 기록 + 보상 레벨 시스템 로직 추가

### DIFF
--- a/apps/api/src/expenses/entity/streak-stats.entity.ts
+++ b/apps/api/src/expenses/entity/streak-stats.entity.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class StreakStatsEntity {
+  @ApiProperty({
+    example: 7,
+    description: '현재 연속 기록 일수',
+  })
+  currentStreak: number;
+
+  @ApiProperty({
+    example: 15,
+    description: '최대 연속 기록 일수',
+  })
+  maxStreak: number;
+
+  @ApiProperty({
+    example: 3,
+    description: '다음 보상까지 남은 일수',
+  })
+  daysToNextReward: number;
+
+  @ApiProperty({
+    example: 10,
+    description: '다음 보상 목표 일수',
+  })
+  nextRewardTarget: number;
+
+  @ApiProperty({
+    example: '2025-07-27',
+    description: '마지막 기록 날짜',
+  })
+  lastRecordDate: string | null;
+
+  @ApiProperty({
+    example: '2025-07-21',
+    description: '현재 연속 기록 시작 날짜',
+  })
+  streakStartDate: string | null;
+
+  @ApiProperty({
+    example: 25,
+    description: '총 기록 일수',
+  })
+  totalRecordDays: number;
+
+  @ApiProperty({
+    example: false,
+    description: '오늘 기록 여부',
+  })
+  hasRecordToday: boolean;
+
+  @ApiProperty({
+    example: 'gold',
+    description: '현재 연속 기록 레벨',
+    enum: ['bronze', 'silver', 'gold', 'platinum', 'diamond'],
+  })
+  streakLevel: 'bronze' | 'silver' | 'gold' | 'platinum' | 'diamond';
+}

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -30,6 +30,7 @@ import { AuthUser } from '@repo/types';
 import { CategoryStatsResponseEntity } from './entity/category-stats.entity';
 import { GetTrendAnalysisDto } from './dto/trend-analysis.dto';
 import { TrendAnalysisEntity } from './entity/trend-analysis.entity';
+import { StreakStatsEntity } from './entity/streak-stats.entity';
 
 @ApiTags('Expense (지출 관련 API)')
 @Controller('expenses')
@@ -470,5 +471,21 @@ export class ExpensesController {
       endYear: dto.endYear,
       endMonth: dto.endMonth,
     });
+  }
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @Get('stats/streak')
+  @ApiOperation({
+    summary: '연속 기록 통계 조회',
+    description: `사용자의 지출 기록 연속 일수와 관련 통계를 조회합니다.
+연속 기록은 하루라도 지출 기록이 있으면 카운트됩니다.
+보상 시스템과 레벨 시스템이 포함되어 있습니다.`,
+  })
+  @ApiOkResponse({
+    type: StreakStatsEntity,
+    description: '연속 기록 통계 조회 성공',
+  })
+  getStreakStats(@getUser() user: AuthUser) {
+    return this.expensesService.getStreakStats(user.id);
   }
 }


### PR DESCRIPTION
구현된 기능:
* 현재 연속 기록 일수 계산
* 최대 연속 기록 일수 계산
* 다음 보상까지 남은 일수
* 오늘 기록 여부 확인
* 연속 기록 레벨 시스템 (bronze → diamond)
* 총 기록 일수 계산

보상 시스템:
* 7일, 14일, 30일, 60일, 100일, 200일, 365일 목표
* 레벨: bronze(기본) → silver(14일) → gold(30일) → platinum(60일) → diamond(100일)