### PR TITLE
feat(web-expense): 연속 지출 기록 레벨

### DIFF
--- a/apps/web/@component/features/cube/streak.expense.tsx
+++ b/apps/web/@component/features/cube/streak.expense.tsx
@@ -1,0 +1,129 @@
+import { StreakInfoResponse } from "@type/expense";
+import {
+  getProgressPercent,
+  getStreakLevel,
+} from "@utils/common/getStreakConfig";
+import React from "react";
+
+const StreakCard: React.FC<{ streak: StreakInfoResponse }> = ({ streak }) => {
+  // 샘플 데이터
+  // const streak = {
+  //   currentStreak: 12,
+  //   maxStreak: 18,
+  //   daysToNextReward: 2,
+  //   nextRewardTarget: 14,
+  //   hasRecordToday: true,
+  //   streakLevel: "silver",
+  //   totalRecordDays: 45,
+  //   streakStartDate: "2025-07-16",
+  // };
+
+  return (
+    <div>
+      {/* 오늘 기록 완료 배지 */}
+      {streak.hasRecordToday && (
+        <div className="absolute top-3 right-3 bg-green-100 text-green-600 text-xs px-2 py-1 rounded-full font-medium">
+          ✓ 오늘 완료
+        </div>
+      )}
+
+      <div className="flex items-center relative z-10">
+        {/* 아이콘과 레벨 표시 */}
+        <div className="relative mr-4">
+          <div
+            className={`w-14 h-14 rounded-full flex items-center justify-center bg-gradient-to-br ${getStreakLevel(streak.streakLevel).color} group-hover:rotate-12 transition-transform duration-300 shadow-lg`}
+          >
+            <span className="text-2xl">🔥</span>
+          </div>
+          {/* 레벨 배지 */}
+          <div className="absolute -bottom-1 -right-1 w-6 h-6 bg-white rounded-full flex items-center justify-center shadow-md border border-gray-200">
+            <span className="text-xs">
+              {getStreakLevel(streak.streakLevel).emoji}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex-1">
+          {/* 메인 텍스트 */}
+          <div className="flex items-center  gap-2 mb-1">
+            <h3 className="font-bold text-lg text-gray-800">
+              {streak.currentStreak}일 연속 기록 중!
+            </h3>
+
+            {/* 레벨과 최고 기록 */}
+            <div className="flex items-center gap-3">
+              <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full font-medium">
+                {streak.streakLevel.toUpperCase()} 레벨
+              </span>
+              <span className="text-xs text-gray-500">
+                최고: {streak.maxStreak}일
+              </span>
+            </div>
+          </div>
+
+          {/* 진행률 바 */}
+          <div className="mb-2">
+            <div className="flex justify-between items-center mb-1">
+              <span className="text-xs text-gray-500">다음 보상까지</span>
+              <span className="text-xs text-gray-600 font-medium">
+                {streak.nextRewardTarget - streak.daysToNextReward}/
+                {streak.nextRewardTarget}
+              </span>
+            </div>
+            <div className="w-full bg-gray-200 rounded-full h-2">
+              <div
+                className={`bg-gradient-to-r ${getStreakLevel(streak.streakLevel).color} h-2 rounded-full transition-all duration-500 ease-out`}
+                style={{
+                  width: `${getProgressPercent({
+                    nextRewardTarget: streak.nextRewardTarget,
+                    daysToNextReward: streak.daysToNextReward,
+                  })}%`,
+                }}
+              />
+            </div>
+          </div>
+
+          <p className="text-sm text-gray-600">
+            꾸준히 기록하면 특별한 보상이 기다려요
+          </p>
+        </div>
+
+        {/* 우측 정보 */}
+        <div className="text-right ml-4">
+          <div className="text-xs text-gray-500 mb-1">남은 일수</div>
+          <div
+            className={`text-2xl font-bold bg-gradient-to-r ${getStreakLevel(streak.streakLevel).color} bg-clip-text text-transparent`}
+          >
+            {streak.daysToNextReward}
+          </div>
+          <div className="text-xs text-gray-500 mt-1">
+            총 {streak.totalRecordDays}일 기록
+          </div>
+        </div>
+      </div>
+
+      {/* 하단 동기부여 메시지 */}
+      <div className="mt-4 pt-3 border-t border-gray-100">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-gray-500">
+            {new Date(streak.streakStartDate || new Date()).toLocaleDateString(
+              "ko-KR"
+            )}
+            부터 시작
+          </span>
+          {streak.daysToNextReward <= 3 ? (
+            <span className="text-xs bg-yellow-100 text-yellow-700 px-2 py-1 rounded-full font-medium animate-pulse">
+              🎁 보상 임박!
+            </span>
+          ) : (
+            <span className="text-xs bg-orange-100 text-orange-700 px-2 py-1 rounded-full font-medium">
+              🔥 연속 중
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StreakCard;

--- a/apps/web/@constant/streak.level.ts
+++ b/apps/web/@constant/streak.level.ts
@@ -1,0 +1,31 @@
+// 레벨별 색상과 이모지
+export const streaklevelConfig: Record<
+  string,
+  { emoji: string; color: string; bgColor: string }
+> = {
+  bronze: {
+    emoji: "🥉",
+    color: "from-orange-400 to-amber-500",
+    bgColor: "from-orange-200/30 to-amber-200/30",
+  },
+  silver: {
+    emoji: "🥈",
+    color: "from-gray-400 to-slate-500",
+    bgColor: "from-gray-200/30 to-slate-200/30",
+  },
+  gold: {
+    emoji: "🥇",
+    color: "from-yellow-400 to-orange-400",
+    bgColor: "from-yellow-200/30 to-orange-200/30",
+  },
+  platinum: {
+    emoji: "💎",
+    color: "from-blue-400 to-purple-500",
+    bgColor: "from-blue-200/30 to-purple-200/30",
+  },
+  diamond: {
+    emoji: "💠",
+    color: "from-purple-400 to-pink-500",
+    bgColor: "from-purple-200/30 to-pink-200/30",
+  },
+};

--- a/apps/web/@hook/api/expense/useExpense.ts
+++ b/apps/web/@hook/api/expense/useExpense.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { YearMonthProps } from "@type/date";
 import { expenseService } from "@utils/apis/services/expense";
 import { userService } from "@utils/apis/services/user";
 import { queryKeys } from "@utils/query/query.key";
@@ -55,16 +56,19 @@ export const useMonthlyExpenses = ({
   });
 };
 
-export const useExpensesCategory = ({
-  year,
-  month,
-}: {
-  year: string;
-  month: string;
-}) => {
+export const useExpensesCategory = ({ year, month }: YearMonthProps) => {
   return useQuery({
     queryKey: queryKeys.expense.category({ year, month }),
     queryFn: () => expenseService.getCategoryStatus({ year, month }),
+    select: (response) => response,
+    staleTime: 5 * 60 * 1000, // 5분
+  });
+};
+
+export const useExpensesStreak = () => {
+  return useQuery({
+    queryKey: queryKeys.expense.streak(),
+    queryFn: () => expenseService.getStreak(),
     select: (response) => response,
     staleTime: 5 * 60 * 1000, // 5분
   });

--- a/apps/web/@hook/business/cube/useCube.ts
+++ b/apps/web/@hook/business/cube/useCube.ts
@@ -2,6 +2,7 @@ import { useBudgetStatus } from "@hook/api/budget/useBudget";
 import {
   useMonthlyExpenses,
   useExpensesCategory,
+  useExpensesStreak,
 } from "@hook/api/expense/useExpense";
 
 export const useCube = ({
@@ -21,33 +22,38 @@ export const useCube = ({
     month,
     day,
   });
-
+  const streakQuery = useExpensesStreak();
   const isLoading =
     budgetQuery.isLoading ||
     expenseCategoryQuery.isLoading ||
-    expensesQuery.isLoading;
+    expensesQuery.isLoading ||
+    streakQuery.isLoading;
   const hasError =
     budgetQuery.isError ||
     expenseCategoryQuery.isError ||
-    expensesQuery.isError;
+    expensesQuery.isError ||
+    streakQuery.isError;
   // budgetHistoryQuery.isError ||
   // recentExpensesQuery.isError;
   const isSuccess =
     budgetQuery.isSuccess ||
     expenseCategoryQuery.isSuccess ||
-    expensesQuery.isSuccess;
+    expensesQuery.isSuccess ||
+    streakQuery.isSuccess;
   // expensesQuery.isSuccess ||
   // recentExpensesQuery.isSuccess;
   console.log({
     budgetQuery: budgetQuery.data,
     expenseCategory: expenseCategoryQuery.data,
     expensesQuery: expensesQuery.data,
+    streakQuery: streakQuery.data,
   });
   return {
     // 개별 쿼리 상태
     budgetQuery: budgetQuery,
     expenseCategoryQuery: expenseCategoryQuery,
     expensesQuery,
+    streakQuery,
 
     // 통합 상태
     isLoading,
@@ -59,6 +65,7 @@ export const useCube = ({
       profile: budgetQuery.error,
       expenseCategory: expenseCategoryQuery.error,
       expensesQuery: expensesQuery.error,
+      streakQuery: streakQuery.error,
     },
   };
 };

--- a/apps/web/@type/expense.ts
+++ b/apps/web/@type/expense.ts
@@ -31,3 +31,15 @@ export interface ExpenseItemListResponse {
   total: number;
   expenses: ExpenseItem[];
 }
+
+export interface StreakInfoResponse {
+  currentStreak: number;
+  maxStreak: number;
+  daysToNextReward: number;
+  nextRewardTarget: number;
+  lastRecordDate: string; // ISO 날짜 문자열
+  streakStartDate: string | null; // null 가능
+  totalRecordDays: number;
+  hasRecordToday: boolean;
+  streakLevel: "bronze" | "silver" | "gold" | "platinum"; // 필요한 경우 enum으로도 가능
+}

--- a/apps/web/@utils/apis/services/expense.ts
+++ b/apps/web/@utils/apis/services/expense.ts
@@ -1,4 +1,8 @@
-import { ExpenseCategorySummary, ExpenseItemListResponse } from "@type/expense";
+import {
+  ExpenseCategorySummary,
+  ExpenseItemListResponse,
+  StreakInfoResponse,
+} from "@type/expense";
 
 import { YearMonthDayProps, YearMonthProps } from "@type/date";
 import { apiClient } from "@utils/apis/api.client";
@@ -16,4 +20,5 @@ export const expenseService = {
       month,
       day,
     }),
+  getStreak: () => apiClient.get<StreakInfoResponse>("/expenses/stats/streak"),
 };

--- a/apps/web/@utils/common/getStreakConfig.ts
+++ b/apps/web/@utils/common/getStreakConfig.ts
@@ -1,0 +1,25 @@
+import { streaklevelConfig } from "@constant/streak.level";
+import { StreakInfoResponse } from "@type/expense";
+
+export function getStreakLevel(level: string) {
+  const currentLevel = streaklevelConfig[level as string] || {
+    emoji: "🥉",
+    color: "from-orange-400 to-amber-500",
+    bgColor: "from-orange-200/30 to-amber-200/30",
+  };
+
+  return currentLevel;
+}
+
+export function getProgressPercent({
+  nextRewardTarget,
+  daysToNextReward,
+}: {
+  nextRewardTarget: StreakInfoResponse["nextRewardTarget"];
+  daysToNextReward: StreakInfoResponse["daysToNextReward"];
+}) {
+  const progressPercentage =
+    ((nextRewardTarget - daysToNextReward) / nextRewardTarget) * 100;
+
+  return progressPercentage;
+}

--- a/apps/web/@utils/query/query.key.ts
+++ b/apps/web/@utils/query/query.key.ts
@@ -26,6 +26,7 @@ export enum BUDGET_SUB_QUERY {
 export enum EXPENSE_SUB_QUERY {
   CATEGORY = "CATEGORY",
   MONTHLY = "MONTHLY",
+  STREAK = "STREAK",
 }
 
 export const queryKeys = {
@@ -75,6 +76,8 @@ export const queryKeys = {
         EXPENSE_SUB_QUERY.MONTHLY,
         { month, year, day },
       ] as const,
+    streak: () =>
+      [...queryKeys.expense.base, EXPENSE_SUB_QUERY.STREAK] as const,
   },
 };
 export const queryFns = {

--- a/apps/web/app/cube/page.tsx
+++ b/apps/web/app/cube/page.tsx
@@ -11,6 +11,7 @@ import InsightExpense from "@component/features/cube/insight.expense";
 import BlockExpense from "@component/features/cube/block.monthly.expense";
 import ListMonthlyExpense from "@component/features/cube/list.monthly.expense";
 import { toYMDWithString } from "@utils/date/YMD";
+import StreakCard from "@component/features/cube/streak.expense";
 
 export default function ExpenseCubePage() {
   const router = useRouter();
@@ -24,6 +25,7 @@ export default function ExpenseCubePage() {
     budgetQuery: { data: budgetStatus },
     expenseCategoryQuery: { data: expenseCategory },
     expensesQuery: { data: expenses },
+    streakQuery: { data: streak },
     isLoading,
     hasError,
     errors,
@@ -48,14 +50,14 @@ export default function ExpenseCubePage() {
         <main className="p-6 space-y-6">
           {/* 연속 기록 배지 */}
           <div className="bg-white rounded-2xl p-5 shadow-sm border border-gray-100 relative overflow-hidden group hover:shadow-md transition-shadow">
-            <div className="absolute top-0 right-0 w-24 h-24 bg-gradient-to-br from-yellow-200/30 to-orange-200/30 rounded-full -translate-y-12 translate-x-12 group-hover:scale-110 transition-transform duration-500" />
+            {/* <div className="absolute top-0 right-0 w-24 h-24 bg-gradient-to-br from-yellow-200/30 to-orange-200/30 rounded-full -translate-y-12 translate-x-12 group-hover:scale-110 transition-transform duration-500" />
             <div className="flex items-center relative z-10">
               <div className="w-14 h-14 rounded-full flex items-center justify-center mr-4 bg-gradient-to-br from-yellow-400 to-orange-400 group-hover:rotate-12 transition-transform duration-300">
                 <span className="text-2xl">🔥</span>
               </div>
               <div className="flex-1">
                 <h3 className="font-bold text-lg text-gray-800">
-                  {7}일 연속 기록 중!
+                  {streak?.currentStreak}일 연속 기록 중!
                 </h3>
                 <p className="text-sm text-gray-600">
                   꾸준히 기록하면 특별한 보상이 기다려요
@@ -64,10 +66,11 @@ export default function ExpenseCubePage() {
               <div className="text-right">
                 <div className="text-xs text-gray-500">다음 보상까지</div>
                 <div className="text-sm font-bold text-yellow-600">
-                  {7 - (7 % 7)}일
+                  {streak?.nextRewardTarget}일
                 </div>
               </div>
-            </div>
+            </div> */}
+            <StreakCard streak={streak!} />
           </div>
 
           {/* 예산 카드 */}


### PR DESCRIPTION
작업 내용
* 오늘 완료 배지: 오늘 기록했는지 표시
* 최고 기록: 개인 최고 연속 기록 표시
* 총 기록 일수: 전체 누적 기록 일수
* 시작 날짜: 현재 연속 기록 시작일
* 레벨별 색상 테마: bronze/silver/gold/platinum/diamond 레벨에 따른 색상
* 레벨 배지: 아이콘 우하단에 레벨 이모지 표시
* 진행률 바: 다음 보상까지의 진행률을 시각적으로 표시