### PR TITLE
refactor(api): 지출 날짜 계산을 일/주/월의 시작·종료 시점 기준으로 처리하도록 개선하여 정확도 향상

### DIFF
--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -84,8 +84,10 @@ export class ExpensesService {
     month: number,
     day: number,
   ) {
-    const start = startOfMonth(new Date(year, month - 1, day));
-    const end = endOfMonth(new Date(year, month - 1, day));
+    const targetDate = new Date(year, month - 1, day);
+
+    const start = startOfDay(targetDate);
+    const end = endOfDay(targetDate);
 
     const expenses = await this.prisma.expense.findMany({
       where: {
@@ -108,11 +110,15 @@ export class ExpensesService {
     month: number,
     day: number,
   ) {
-    const start = startOfWeek(new Date(year, month - 1, 1), {
-      weekStartsOn: 1,
-    }); // 월요일 시작
-    const end = endOfWeek(new Date(year, month - 1, 1), { weekStartsOn: 1 });
+    const targetDate = new Date(year, month - 1, day);
 
+    const start = startOfWeek(targetDate, {
+      weekStartsOn: 1, // 월요일 시작
+    });
+
+    const end = endOfWeek(targetDate, {
+      weekStartsOn: 1,
+    });
     const expenses = await this.prisma.expense.findMany({
       where: {
         userId,
@@ -132,6 +138,7 @@ export class ExpensesService {
     userId: string,
     year: number,
     month: number,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     day: number,
   ) {
     const start = startOfMonth(new Date(year, month - 1, 1));
@@ -154,11 +161,14 @@ export class ExpensesService {
     return { total, expenses };
   }
   async getCategoryStats(userId: string, year: number, month: number) {
-    const start = startOfMonth(new Date(year, month - 1, 1));
-    const end = endOfMonth(new Date(year, month - 1, 1));
+    const targetDate = new Date(year, month - 1);
 
-    // 해당 월의 모든 지출 데이터 조회
-    const expenses = await this.prisma.expense.findMany({
+    const start = startOfMonth(targetDate);
+    const end = endOfMonth(targetDate);
+
+    // 1) Prisma에서 카테고리별 합계 + 건수를 바로 집계
+    const grouped = await this.prisma.expense.groupBy({
+      by: ['category'],
       where: {
         userId,
         expenseDate: {
@@ -166,12 +176,12 @@ export class ExpensesService {
           lte: end,
         },
       },
-      orderBy: {
-        amount: 'desc',
-      },
+      _sum: { amount: true },
+      _count: { amount: true },
     });
 
-    if (expenses.length === 0) {
+    // 집계할 데이터가 없다면 빈 데이터 반환
+    if (grouped.length === 0) {
       return {
         totalAmount: 0,
         totalCount: 0,
@@ -179,43 +189,27 @@ export class ExpensesService {
       };
     }
 
-    // 카테고리별 집계
-    const categoryMap = new Map<string, { amount: number; count: number }>();
-    let totalAmount = 0;
+    // 2) 전체 금액
+    const totalAmount = grouped.reduce(
+      (sum, c) => sum + (c._sum.amount ?? 0),
+      0,
+    );
+    const totalCount = grouped.reduce((sum, c) => sum + c._count.amount, 0);
 
-    expenses.forEach((expense) => {
-      const category = expense.category;
-      const amount = expense.amount;
-
-      totalAmount += amount;
-
-      if (categoryMap.has(category)) {
-        const existing = categoryMap.get(category)!;
-        categoryMap.set(category, {
-          amount: existing.amount + amount,
-          count: existing.count + 1,
-        });
-      } else {
-        categoryMap.set(category, {
-          amount: amount,
-          count: 1,
-        });
-      }
-    });
-
-    // 결과 변환 및 정렬 (금액 기준 내림차순)
-    const categories = Array.from(categoryMap.entries())
-      .map(([category, data]) => ({
-        category,
-        amount: data.amount,
-        count: data.count,
-        percentage: totalAmount > 0 ? (data.amount / totalAmount) * 100 : 0,
+    // 3) 카테고리별 비율 포함 데이터 변환
+    const categories = grouped
+      .map((c) => ({
+        category: c.category,
+        amount: c._sum.amount ?? 0,
+        count: c._count.amount,
+        percentage:
+          totalAmount > 0 ? ((c._sum.amount ?? 0) / totalAmount) * 100 : 0,
       }))
-      .sort((a, b) => b.amount - a.amount);
+      .sort((a, b) => b.amount - a.amount); // 가장 많이 쓴 카테고리 순으로 정렬
 
     return {
       totalAmount,
-      totalCount: expenses.length,
+      totalCount,
       categories,
     };
   }


### PR DESCRIPTION
## 일간 지출 합계
```
  const targetDate = new Date(year, month - 1, day);
  const start = startOfDay(targetDate);
  const end = endOfDay(targetDate);
```

## 주간 지출 합계
반드시 day를 포함한 기준 날짜로 주간 범위를 계산해야 함
```
  const targetDate = new Date(year, month - 1, day);
  const start = startOfWeek(targetDate, {
    weekStartsOn: 1, // 월요일 시작
  });
  const end = endOfWeek(targetDate, {
    weekStartsOn: 1,
  });
```

## 카테고리 분석 개선

### **✔  Prisma groupBy로 서버 쿼리 최적화**

기존 방식: 모든 레코드 find → JS에서 Map으로 그룹화
개선 방식: DB에서 GROUP BY category 실행
레코드 수가 많아질수록 이 방식이 훨씬 빠름
```
const results = await prisma.expense.groupBy({
  by: ["category"],
  where: { userId, expenseDate: { gte: start, lte: end } },
  _sum: { amount: true },
  _count: true,
});
```

### 🧠 왜 이 버전이 가장 발전형인가?

| 개선 포인트 | 설명 |
|------------|-------|
| **DB 집계 사용 (`groupBy`)** | 대량 데이터에서도 빠르게 처리 가능하며, JS에서 `reduce`로 다시 계산할 필요 없음 |
| **총합·총개수도 DB에서 한 번에** | `aggregate()`를 통해 한 번에 계산 → 중복 계산 실수 방지 |
| **조기 리턴** | 불필요한 조건문, map 반복 처리 최소화 → 성능 향상 |
| **정렬도 `groupBy`에서 처리** | 프론트에서 정렬할 필요 없어짐 → 불필요한 연산 제거 |
| **percentage 정밀도 관리** | `toFixed(1)`로 UI-friendly 소수점 표시 |
| **타입 안정성 강화** | Prisma가 반환 타입을 보장 → 런타임 오류 감소 |

